### PR TITLE
Closes #6 - Bugfix to escape characters

### DIFF
--- a/includes/admin-setup.php
+++ b/includes/admin-setup.php
@@ -81,7 +81,7 @@ function acfw_how_to_meta_box( $post ) {
 		echo "<p>Add a new field group and set the <i>Location</i> equal to: <b>Widget is equal to {$post->post_title}</b>.</p>";
 		echo "<p>To show this widget in your theme, add a new template file to your theme directory named <strong>widget-{$post->post_name}.php</strong> or <strong>widget-{$post->ID}.php</strong> .</p>";
 		echo "<p>You can show the values from your widgets in your templates by using the following syntax.</p>";
-		echo "<code>&lt;?php the_field(\'YOUR_FIELD_NAME\', \$acfw); ?&gt;</code>";
+		echo "<code>&lt;?php the_field('YOUR_FIELD_NAME', \$acfw); ?&gt;</code>";
 		echo "<p><a href='https://www.youtube.com/watch?v=YRfvqmSQG7o' target='_blank'>Watch Tutorial</a> or <a href='http://acfwidgets.com/support/'>Read More</a></p>";
 	}
 }

--- a/includes/widgets-setup.php
+++ b/includes/widgets-setup.php
@@ -23,8 +23,8 @@ function acfw_setup_classes(){
 	
 	foreach ($results as $result) :
 		
-		$title = $result->post_title;
-		$description = $result->post_excerpt;
+		$title = esc_attr($result->post_title);
+		$description = esc_attr($result->post_excerpt);
 		$slug = $result->post_name;
 		$id = $result->ID;
 
@@ -41,9 +41,9 @@ function acfw_included_widgets(){
 	if ( !empty($acfw_included_widgets) ) :
 		foreach ( $acfw_included_widgets as $widget ):
 			
-			$title = $widget['title'];
+			$title = esc_attr($widget['title']);
+			$description = esc_attr($widget['description']);
 			$slug = $widget['slug'];
-			$description = $widget['description'];
 			$id = $widget['id'];
 		
 			acfw_widgets_eval($title, $description, $slug, $id);


### PR DESCRIPTION
Escape characters in widget titles and descriptions so as to not upset
the natural balance of the `eval`.
