### PR TITLE
Add widget slug to frontend HTML element classes

### DIFF
--- a/includes/ACFW_Widget.php
+++ b/includes/ACFW_Widget.php
@@ -25,7 +25,7 @@ class ACFW_Widget extends WP_Widget {
 			__( $this->title, 'acfw' ), // Name
 			array( 
 				'description' => __( $this->description, 'acfw' ), 
-				'classname' => $this->data_id . ' ' . $old_classname . ' ' . $this->classes, // class ID  + custom stuff
+				'classname' => $this->slug . ' ' . $this->data_id . ' ' . $old_classname . ' ' . $this->classes, // class ID  + custom stuff
 			) // Args
 		);
       


### PR DESCRIPTION
Makes the widget output more CSS-friendly by adding the plain english (non-post-ID-specific) slug in the classes of the frontend HTML element markup when sprintf variables are used in the register_sidebar function. i.e.: `register_sidebar(['before_widget' => '<section class="widget %1$s %2$s”>’]);`

This aids in migrating widget code between websites without changing css class selectors.
