### PR TITLE
Updating display_titles() function

### DIFF
--- a/includes/ACFW_Widget.php
+++ b/includes/ACFW_Widget.php
@@ -132,17 +132,17 @@ class ACFW_Widget extends WP_Widget {
      */
     public function display_titles() {
 
-    	if ( apply_filters("show_acfw_titles" , false ) )
+        if ( apply_filters( "show_acfw_title_{$this->slug}", false ) )
+            return true;
+        elseif ( apply_filters( "hide_acfw_title_{$this->slug}", false ) )
+            return false;
+        elseif ( apply_filters( "show_acfw_title_{$this->post_id}", false ) )
+            return true;
+        elseif ( apply_filters( "hide_acfw_title_{$this->post_id}", false ) )
+            return false;
+    	elseif ( apply_filters( "show_acfw_titles" , false ) )
     		return true;
-    	elseif ( apply_filters("hide_acfw_titles" , false ) )
-    		return false;
-    	elseif ( apply_filters( "show_acfw_title_{$this->slug}", false ) )
-    		return true;
-    	elseif ( apply_filters( "hide_acfw_title_{$this->slug}", false ) )
-    		return false;
-    	elseif ( apply_filters( "show_acfw_title_{$this->post_id}", false ) )
-    		return true;
-    	elseif ( apply_filters( "hide_acfw_title_{$this->post_id}", false ) )
+    	elseif ( apply_filters( "hide_acfw_titles" , false ) )
     		return false;
     	else
     		return false;


### PR DESCRIPTION
Changing the filter priority to allow titles to still be shown/hided for specific slugs or post_ids even when the global show/hide filter has been set.

So for example. If we want titles in the backend for all widget except "donate".

``` php
add_action('init', function(){
    if (is_admin()) {
        add_filter('show_acfw_titles', '__return_true');
        add_filter('hide_acfw_title_donate', '__return_true');
    }
});
```
