### PR TITLE
Fixing global scope error

### DIFF
--- a/acf-widgets.php
+++ b/acf-widgets.php
@@ -32,7 +32,7 @@ function acfw_globals(){
 include_once('includes/acf-404.php');
 
 
-$acfw_default_widgets = array('pages', 'calendar', 'archives', 'meta', 'search', 'text', 
+$GLOBALS['acfw_default_widgets'] = array('pages', 'calendar', 'archives', 'meta', 'search', 'text', 
 	'categories', 'recent-posts', 'recent-comments', 'rss', 'tag_cloud', 'nav_menu');
 
 include_once('includes/helper-functions.php');


### PR DESCRIPTION
Unless accessed via `$GLOBALS` or using the `global` keyword the variable may or may not be in the global scope. Which will result in the following error.

```
PHP error:  Argument 1 passed to acfw_location_rules() must be of the type array, null given
```

This won't be an issue most of the time in Wordpress as all the plugins are included from the global scope. However if you're bootstrapping Wordpress in another context (i.e. not using Wordpress' index.php) this may not be the case. For example if you want bootstrap Wordpress while using the PsySH REPL.

``` php
<?php /* bootstrap.php */
define('WP_USE_THEMES', true);
require __DIR__.'/wp-load.php';
```

``` bash
psysh bootstrap.php
```

A more extreme example would be if you wanted to use Wordpress together with a Laravel app. In your Laravel exception handler you put something like this.

``` php
    /**
     * Render an exception into an HTTP response.
     *
     * @param  \Illuminate\Http\Request  $request
     * @param  \Exception  $e
     * @return \Illuminate\Http\Response
     */
    public function render($request, Exception $e)
    {
        // Fallback to WordPress for routes not handled in Laravel
        if ($e instanceof NotFoundHttpException) {
            define('WP_USE_THEMES', true);
            require public_path('wp-blog-header.php');
            exit;
        }

        return parent::render($request, $e);
    }
```
