### PR TITLE
Illegal offset error

### DIFF
--- a/acf-widgets.php
+++ b/acf-widgets.php
@@ -3,7 +3,7 @@
 * Plugin Name: ACF Widgets
 * Plugin URI: https://acfwidgets.com
 * Description: A plugin to easily create widgets for use with ACF and add custom fields to any widget on your site.
-* Version: 1.11
+* Version: 1.12
 * Tested up to: 4.9
 * Author: Daron Spence
 * Author URI: http://acfwidgets.com

--- a/includes/ACFW_Widget_Factory.php
+++ b/includes/ACFW_Widget_Factory.php
@@ -15,7 +15,9 @@ class ACFW_Widget_Factory extends WP_Widget_Factory {
 		if ( !empty($params) ) {
 			$key .= '_' . $params['id'];
 		}
-		$this->widgets[$key] = new $widget_class($params);
+		if ( !is_object( $key ) ) {
+			$this->widgets[$key] = new $widget_class($params);
+		}
 	}
 
 


### PR DESCRIPTION
Ran into the error _Illegal offset type_ on line 18 of `ACFW_Widget_Factory.php`. 

`$this->widgets[$key]` expects a string but I found the Simple Share Buttons plugin passes an object at this point. This is not correct, but I've added a conditional to check that we're not passing an object.